### PR TITLE
Fixing issue with backup that occurs with older versions of SABnzb

### DIFF
--- a/sherpa.sh
+++ b/sherpa.sh
@@ -913,7 +913,7 @@ BackupThisPackage()
         fi
 
         if [[ ! -d ${BACKUP_PATH}/config ]]; then
-            mv "$package_config_path" "$BACKUP_PATH"
+            mv "$package_config_path" "$BACKUP_PATH/config/"
             mvresult=$?
 
             [[ -e $backup_pathfile ]] && rm "$backup_pathfile"


### PR DESCRIPTION
This fails when the original config folder is upper cased such as in older versions of SABnzbd. Tested using SAB 0.7 on QNAP 4.2.x. Upgraded, migrated config and worked fine after this fix.